### PR TITLE
Add layout and listings pages

### DIFF
--- a/apps/guest-web/index.html
+++ b/apps/guest-web/index.html
@@ -1,21 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/webp" href="/logo.webp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Atlas Homestays - Premium service apartments in KPHB" />
     <title>Atlas Homestays</title>
-
-    <!-- Optional Fonts and Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 </head>
-
 <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
-
 </html>

--- a/apps/guest-web/src/App.jsx
+++ b/apps/guest-web/src/App.jsx
@@ -1,16 +1,20 @@
-// guest-web/src/App.jsx
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import GuestBooking from './pages/GuestBooking';
+import Listings from './pages/Listings';
+import ListingDetails from './pages/ListingDetails';
+import Layout from './components/Layout';
 
 function App() {
     return (
-        <>
-            <Routes>
+        <Routes>
+            <Route element={<Layout />}>
                 <Route path="/" element={<Home />} />
+                <Route path="/listings" element={<Listings />} />
+                <Route path="/listings/:id" element={<ListingDetails />} />
                 <Route path="/guest-booking" element={<GuestBooking />} />
-            </Routes>
-        </>
+            </Route>
+        </Routes>
     );
 }
 

--- a/apps/guest-web/src/components/Footer.jsx
+++ b/apps/guest-web/src/components/Footer.jsx
@@ -1,9 +1,10 @@
-// File: src/components/Footer.jsx
 import React from 'react';
 
 const Footer = () => (
-    <footer className="site-footer">
-        <p>&copy; {new Date().getFullYear()} Atlas Homestays. All rights reserved.</p>
+    <footer className="site-footer bg-dark text-light py-4 mt-auto">
+        <div className="container text-center">
+            <p className="mb-0">&copy; {new Date().getFullYear()} Atlas Homestays. All rights reserved.</p>
+        </div>
     </footer>
 );
 

--- a/apps/guest-web/src/components/Header.jsx
+++ b/apps/guest-web/src/components/Header.jsx
@@ -1,5 +1,28 @@
-<nav>
-    <a href="/">Home</a>
-    <a href="/book">Book Now</a>
-    <a href="/guest-booking">Multi-Listing Booking</a> {/* 👈 Add this */}
-</nav>
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Header = () => (
+    <header className="site-header navbar navbar-expand-lg navbar-dark bg-primary">
+        <div className="container">
+            <Link className="navbar-brand" to="/">Atlas Homestays</Link>
+            <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span className="navbar-toggler-icon"></span>
+            </button>
+            <div className="collapse navbar-collapse" id="navbarNav">
+                <ul className="navbar-nav ms-auto">
+                    <li className="nav-item">
+                        <Link className="nav-link" to="/">Home</Link>
+                    </li>
+                    <li className="nav-item">
+                        <Link className="nav-link" to="/listings">Listings</Link>
+                    </li>
+                    <li className="nav-item">
+                        <Link className="nav-link" to="/guest-booking">Multi-Listing Booking</Link>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </header>
+);
+
+export default Header;

--- a/apps/guest-web/src/components/Layout.jsx
+++ b/apps/guest-web/src/components/Layout.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from './Header';
+import Footer from './Footer';
+import { Outlet } from 'react-router-dom';
+
+const Layout = () => (
+    <>
+        <Header />
+        <main className="container my-4">
+            <Outlet />
+        </main>
+        <Footer />
+    </>
+);
+
+export default Layout;

--- a/apps/guest-web/src/pages/Home.jsx
+++ b/apps/guest-web/src/pages/Home.jsx
@@ -1,11 +1,12 @@
-// File: src/pages/Home.jsx
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Home = () => (
-    <section>
-        <h2>Welcome to Atlas Homestays</h2>
-        <p>Premium Service Apartments in KPHB.</p>
-    </section>
+    <div className="text-center">
+        <h1 className="display-4">Welcome to Atlas Homestays</h1>
+        <p className="lead">Premium Service Apartments in KPHB.</p>
+        <Link to="/listings" className="btn btn-primary btn-lg">Browse Listings</Link>
+    </div>
 );
 
 export default Home;

--- a/apps/guest-web/src/pages/ListingDetails.jsx
+++ b/apps/guest-web/src/pages/ListingDetails.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import { API_BASE } from '../config';
+
+const ListingDetails = () => {
+    const { id } = useParams();
+    const [listing, setListing] = useState(null);
+
+    useEffect(() => {
+        axios.get(`${API_BASE}/listings/${id}`).then(res => setListing(res.data));
+    }, [id]);
+
+    if (!listing) return <p>Loading...</p>;
+
+    return (
+        <div className="card">
+            <img src="https://via.placeholder.com/800x400?text=Listing" className="card-img-top" alt={listing.name} />
+            <div className="card-body">
+                <h3 className="card-title">{listing.name}</h3>
+                <p className="card-text">Type: {listing.type}</p>
+                <p className="card-text">Max Guests: {listing.maxGuests}</p>
+            </div>
+        </div>
+    );
+};
+
+export default ListingDetails;

--- a/apps/guest-web/src/pages/Listings.jsx
+++ b/apps/guest-web/src/pages/Listings.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import { API_BASE } from '../config';
+
+const Listings = () => {
+    const [listings, setListings] = useState([]);
+
+    useEffect(() => {
+        axios.get(`${API_BASE}/listings`).then(res => setListings(res.data));
+    }, []);
+
+    return (
+        <div className="row">
+            {listings.map(listing => (
+                <div className="col-md-4 mb-4" key={listing.id}>
+                    <div className="card h-100">
+                        <img src="https://via.placeholder.com/400x300?text=Listing" className="card-img-top" alt={listing.name} />
+                        <div className="card-body d-flex flex-column">
+                            <h5 className="card-title">{listing.name}</h5>
+                            <p className="card-text">Sleeps {listing.maxGuests} guests</p>
+                            <Link className="btn btn-primary mt-auto" to={`/listings/${listing.id}`}>View Details</Link>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default Listings;

--- a/apps/guest-web/src/style.css
+++ b/apps/guest-web/src/style.css
@@ -1,24 +1,12 @@
 body {
-    font-family: sans-serif;
-    margin: 0;
-    padding: 0;
-    background-color: #f9f9f9;
+    font-family: Arial, sans-serif;
 }
 
-.site-header,
+.site-header {
+    margin-bottom: 0;
+}
+
 .site-footer {
     background-color: #003366;
-    color: white;
-    padding: 1rem;
-    text-align: center;
-}
-
-nav a {
-    margin: 0 1rem;
-    color: white;
-    text-decoration: none;
-}
-
-main {
-    padding: 2rem;
+    color: #fff;
 }

--- a/apps/guest-web/vite.config.js
+++ b/apps/guest-web/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    base: './',
+});


### PR DESCRIPTION
## Summary
- add Bootstrap-powered header and footer
- use Layout wrapper in guest web routes
- add listings overview and detail pages
- style guest web with basic CSS and include Bootstrap
- set relative base path for guest-web

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f4058ea0832b93c4e2179b546352