### PR TITLE
Remove duplicate patterns from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,4 @@ obj/
 *.vsidx
 *.suo
 *.user
-*.log
-bin/
-obj/
-node_modules/
 dist/


### PR DESCRIPTION
## Summary
- deduplicate `node_modules/`, `bin/`, `obj/`, and `*.log` entries in `.gitignore`

## Testing
- `npm test` *(fails: missing script)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527325adc4832bbc65c9e4db730ff4