### PR TITLE
Remove hard-coded connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,26 @@ This monorepo contains all the technology components for **Atlas Homestays** —
 - **Custom Domains:**
   - `admin.atlashomestays.com` → Cloudflare Pages (React app)
   - `atlas-homes-api...azurewebsites.net` → Azure API endpoint
+---
+
+## Local Development
+
+The API requires a connection string named `DefaultConnection`. This value is no
+longer stored in `appsettings.json`. Configure it through environment variables
+or the .NET user-secrets feature:
+
+```bash
+# Example temporary shell variable
+export ConnectionStrings__DefaultConnection="Server=...;Database=...;User
+ID=...;Password=..."
+
+# Or store it with user secrets
+cd backend/api/Atlas.Api
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=...;Datab
+ase=...;User ID=...;Password=..."
+```
+
+Other sensitive values should be provided the same way instead of being
+committed to source control.
 
 ---

--- a/backend/api/Atlas.Api/Atlas.Api.csproj
+++ b/backend/api/Atlas.Api/Atlas.Api.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+  <TargetFramework>net8.0</TargetFramework>
+  <Nullable>enable</Nullable>
+  <ImplicitUsings>enable</ImplicitUsings>
+  <UserSecretsId>b167d940-ed1f-473c-82ef-1c636ec7a97b</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/api/Atlas.Api/appsettings.json
+++ b/backend/api/Atlas.Api/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=atlashomestays-sqldb.database.windows.net;Database=atlasdb;User Id=sqladmin;Password=Welcome01@;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- drop database connection string from `appsettings.json`
- enable user secrets for Atlas.Api
- document how to supply `DefaultConnection` locally

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68527324c4ec832b8e26bdbda490add7