### PR TITLE
Fix missing React import in guest-web

### DIFF
--- a/apps/guest-web/src/App.jsx
+++ b/apps/guest-web/src/App.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import GuestBooking from './pages/GuestBooking';


### PR DESCRIPTION
## Summary
- include React import in `App.jsx` so JSX compiles correctly

## Testing
- `npm run build` in `apps/guest-web`


------
https://chatgpt.com/codex/tasks/task_e_68512f7cdbd0832b8affafa1894fc16b