### PR TITLE
Fix missing Alert import

### DIFF
--- a/apps/admin-portal/src/pages/Bookings.jsx
+++ b/apps/admin-portal/src/pages/Bookings.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import {
   Box, Button, CircularProgress, FormControl, InputLabel, MenuItem,
   Select, TextField, Typography, Table, TableHead, TableRow, TableCell,
-  TableBody, Paper, Card, CardContent,TablePagination 
+  TableBody, Paper, Card, CardContent, TablePagination, Alert
 } from '@mui/material';
 import '../style.css';
 


### PR DESCRIPTION
## Summary
- include Alert in Booking page imports

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f405a984832bab0a7b418543f3ca