### PR TITLE
Wrap dev exception page in Program

### DIFF
--- a/backend/api/Atlas.Api/Program.cs
+++ b/backend/api/Atlas.Api/Program.cs
@@ -42,7 +42,10 @@ namespace Atlas.Api
                 c.RoutePrefix = "swagger"; // ensures URL ends with /swagger
             });
 
-            app.UseDeveloperExceptionPage(); // Add this line for dev environment
+            if (app.Environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage(); // Use detailed error page only in development
+            }
             app.UseHttpsRedirection();
             app.UseCors();
             app.UseAuthorization();


### PR DESCRIPTION
## Summary
- ensure the developer exception page runs only in development mode

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d037455c832bb84b42c8e2562f5e