### PR TITLE
Update guest web links to use react-router

### DIFF
--- a/apps/guest-web/src/components/Header.jsx
+++ b/apps/guest-web/src/components/Header.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Header = () => (
     <nav>
-        <a href="/">Home</a>
-        <a href="/book">Book Now</a>
-        <a href="/guest-booking">Multi-Listing Booking</a>
+        <Link to="/">Home</Link>
+        <Link to="/book">Book Now</Link>
+        <Link to="/guest-booking">Multi-Listing Booking</Link>
     </nav>
 );
 


### PR DESCRIPTION
## Summary
- use `Link` from `react-router-dom` in the Header
- verify Layout wraps all routes

## Testing
- `npm run build` in `apps/guest-web`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852d112b51c832b8904ce0baa7340c0