### PR TITLE
Add environment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,10 @@ This monorepo contains all the technology components for **Atlas Homestays** —
   - `admin.atlashomestays.com` → Cloudflare Pages (React app)
   - `atlas-homes-api.azurewebsites.net` → Azure API endpoint
 
+### ⚙️ Environment Configuration
+- Copy the provided `.env.example` in each project and rename to `.env`:
+  - `apps/guest-web/.env.example` – sets `VITE_API_BASE` for the guest site.
+  - `apps/admin-portal/.env.example` – sets `VITE_API_BASE` plus Auth0 `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`.
+  - `backend/api/Atlas.Api/.env.example` – sets `ConnectionStrings__DefaultConnection` for the API.
+
 ---

--- a/apps/admin-portal/.env.example
+++ b/apps/admin-portal/.env.example
@@ -1,0 +1,6 @@
+# Base URL for backend API
+VITE_API_BASE=http://localhost:5000
+
+# Auth0 configuration
+VITE_AUTH0_DOMAIN=your-auth0-domain
+VITE_AUTH0_CLIENT_ID=your-auth0-client-id

--- a/apps/guest-web/.env.example
+++ b/apps/guest-web/.env.example
@@ -1,0 +1,2 @@
+# Base URL for backend API
+VITE_API_BASE=http://localhost:5000

--- a/backend/api/Atlas.Api/.env.example
+++ b/backend/api/Atlas.Api/.env.example
@@ -1,0 +1,2 @@
+# Database connection string
+ConnectionStrings__DefaultConnection=Server=YOUR_SERVER;Database=atlasdb;User Id=sqladmin;Password=YourPassword;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;


### PR DESCRIPTION
## Summary
- provide `.env.example` for guest-web app
- provide `.env.example` for admin-portal app
- provide `.env.example` for Atlas.Api
- document environment files in README

## Testing
- `npm install` & `npm run build` in `apps/guest-web`
- `npm install` & `npm run build` in `apps/admin-portal`
- ❌ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d11538d4832ba38ba4355524eb92