### PR TITLE
Add governance and PR template docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+### 📝 Pull Request Summary
+
+> Briefly explain the changes made in this PR.
+
+---
+
+### 📍 Checklist
+
+- [ ] PR is raised from `dev` branch
+- [ ] PR merges into `main` only
+- [ ] Code has been tested locally
+- [ ] No secrets (.env) are committed
+- [ ] Follows repo naming and folder structure
+
+---
+
+### 🚨 Notes
+
+> Add any context, deployment info, or known issues.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,18 @@
+# Governance - Atlas Homestays Repository
+
+## 🔒 Branching Policy
+
+- `main` is production-ready and protected.
+- `dev` is the working branch for all merges from feature branches.
+- `feature/*` branches should be used for individual tasks and features.
+
+## ✅ PR Policy
+
+- All changes must go through Pull Requests.
+- `main` must only be updated via a PR from `dev`.
+- Minimum 1 review is required before merging to `main`.
+
+## 🚫 No Secrets Policy
+
+- `.env` files must not be committed.
+- Use `.env.example` instead and store real secrets in GitHub Actions Secrets or environment managers.


### PR DESCRIPTION
## Summary
- add a default pull request template
- document governance policies for repo

## Testing
- `dotnet test backend/api/Atlas.Api.Tests/Atlas.Api.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6853f872cb9c832bb7fc81401cc0dc38